### PR TITLE
use parent's stdios

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,8 @@ Child.prototype.start = function() {
   var sig = "["+colors.green("bg")+"]";
   console.log(sig, "Starting", this.cmd, this.args.join(" "));
 
-  this.proc = spawn(this.cmd, this.args);
+  this.proc = spawn(this.cmd, this.args, { stdio: 'inherit' });
 
-  this.proc.stdout.on("data", this.log);
-  this.proc.stderr.on("data", this.err);
   this.proc.on("exit", this.exit.bind(this));
 
   this.running = true;
@@ -38,22 +36,9 @@ Child.prototype.restart = function() {
 };
 
 Child.prototype.exit = function(code) {
-  var fn = code === 0 ? "log" : "err";
-  this[fn]("Exited with code "+code);
   this.running = false;
-};
-
-Child.prototype.log = function(buff) { 
-  var msg = buff.toString().trim();
-  var sig = "["+colors.gray("bg")+"]";
-  console.log(sig, msg);
-};
-
-Child.prototype.err = function(buff) {
-  var msg = buff.toString().trim();
-  var sig = "["+colors.red("bg")+"]";
-
-  if (!msg) return;
+  var msg = "Exited with code "+code;
+  var sig = "["+colors[code === 0 ? "gray" : "red"]("bg")+"]";
   console.log(sig, msg);
 };
 
@@ -61,7 +46,7 @@ var plugin = module.exports = function(cmd, args) {
   if (!(args instanceof Array)) {
     args = Array.prototype.slice.call(arguments, 1);
   }
-  
+
   var child = new Child(cmd, args);
 
   return child.restart.bind(child);


### PR DESCRIPTION
What do you think about using the parent's stdios?

This comes in handy, e.g., when the child has colored outputs, like when using [debug](https://github.com/visionmedia/debug)

With own stdios:
![screenshot 2014-05-09 13 43 53](https://cloud.githubusercontent.com/assets/409021/2927610/46e1f826-d76f-11e3-8db1-31c98c4f99d5.png)

With parent's stidos:
![screenshot 2014-05-09 13 43 36](https://cloud.githubusercontent.com/assets/409021/2927612/4df44b64-d76f-11e3-8348-dfa85796cc24.png)
